### PR TITLE
try to fix automount

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -19,6 +19,15 @@ if [[ $FSTYPE_LIST == *lxfs* || $FSTYPE_LIST == *wslfs* ]] ; then
     exit 1
 fi
 
+# avoid first run
+if [[ -z "$(df | grep 'C:')" ]] ; then
+    exec $(echo ${@} | sed 's#/sbin/#/usr/.bin/#g' | sed 's#^/usr/bin/#/usr/.bin/#g')
+fi 
+
+# debug
+if [[ "${@}" =~ "_debug" ]] ; then
+    exec bash
+fi 
 
 CONTAINER_PID=$(pgrep -xo systemd)
 


### PR DESCRIPTION
Fix automount issue after updating to 21h2(19044.1200).

wsl2 tries to run `/sbin/ldconfig` at first boot, but there is no automount environment at this boot.
So the startup of systemd should be skipped at this boot.